### PR TITLE
Issue15: move from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ packages = ["freecad", "freecad.workbench_starterkit"]
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = {attr = "freecad.workbench_starterkit.version.__version__"}
+version = {attr = "freecad.workbench_starterkit.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+# References: 
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+# https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages
+# https://packaging.python.org/en/latest/guides/single-sourcing-package-version/
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "freecad.workbench_starterkit"
+dynamic = ["version"]
+description = "template for a freecad extensions, installable with pip"
+readme = "README.md"
+license = {file = "LICENSE"}
+maintainers = [
+    {name = "looooo", email = "sppedflyer@gmail.com"},
+]
+requires-python = ">=3.8"
+dependencies = ["numpy"]
+
+[project.urls]
+source = "https://github.com/FreeCAD/freecad.workbench_starterkit"
+
+[tool.setuptools]
+packages = ["freecad", "freecad.workbench_starterkit"]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+version = {attr = "freecad.workbench_starterkit.version.__version__"}

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,12 @@
+"""
+We keep this file to support legacy builds and editable installs,
+while keeping all configuration in pyproject.toml
+
+References:
+
+    https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+"""
+
 from setuptools import setup
-import os
-# from freecad.workbench_starterkit.version import __version__
-# name: this is the name of the distribution.
-# Packages using the same name here cannot be installed together
 
-version_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 
-                            "freecad", "workbench_starterkit", "version.py")
-with open(version_path) as fp:
-    exec(fp.read())
-
-setup(name='freecad.workbench_starterkit',
-      version=str(__version__),
-      packages=['freecad',
-                'freecad.workbench_starterkit'],
-      maintainer="looooo",
-      maintainer_email="sppedflyer@gmail.com",
-      url="https://github.com/FreeCAD/Workbench-Starterkit",
-      description="template for a freecad extensions, installable with pip",
-      install_requires=['numpy'], # should be satisfied by FreeCAD's system dependencies already
-      include_package_data=True)
+setup()


### PR DESCRIPTION
Moves metadata from setup.py to a minimal pyproject.toml.

A minimal version of setup.py is maintained for compatibility reasons.

Tested with freecad v19.

Fixes #15